### PR TITLE
Make integration tests more robust

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,9 @@ async-timeout==3.0.1 \
 attrs==19.3.0 \
     --hash=sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c \
     --hash=sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72
-ccxt==1.25.39 \
-    --hash=sha256:037bc5b6668baa633f023646b07863a02fc6c2d9f2f6ad6803dce3248c6ffed5 \
-    --hash=sha256:7e135b69e71176b9ff26cebf3eddf4789f9390a18aee8de002bb765485a215c3
+ccxt==1.31.12 \
+    --hash=sha256:03e00d543524c5e52e32852df8c8d0a281b06b9c26be226f3a383ebfe67047be \
+    --hash=sha256:997ec9058610b17bd83023796dbe4d0767b92279806b3c21881aa262eefd16f6
 certifi==2019.9.11 \
     --hash=sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50 \
     --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef

--- a/tests/integration/exchange.py
+++ b/tests/integration/exchange.py
@@ -9,40 +9,6 @@ KRAKEN_BTC_USD = {
     'baseId': 'XXBT',
     'darkpool': False,
     'id': 'XXBTZUSD',
-    'info': {
-        'aclass_base': 'currency',
-        'aclass_quote': 'currency',
-        'altname': 'XBTUSD',
-        'base': 'XXBT',
-        'fee_volume_currency': 'ZUSD',
-        'fees': [[0, 0.26],
-                 [50000, 0.24],
-                 [100000, 0.22],
-                 [250000, 0.2],
-                 [500000, 0.18],
-                 [1000000, 0.16],
-                 [2500000, 0.14],
-                 [5000000, 0.12],
-                 [10000000, 0.1]],
-        'fees_maker': [[0, 0.16],
-                       [50000, 0.14],
-                       [100000, 0.12],
-                       [250000, 0.1],
-                       [500000, 0.08],
-                       [1000000, 0.06],
-                       [2500000, 0.04],
-                       [5000000, 0.02],
-                       [10000000, 0]],
-        'leverage_buy': [2, 3, 4, 5],
-        'leverage_sell': [2, 3, 4, 5],
-        'lot': 'unit',
-        'lot_decimals': 8,
-        'lot_multiplier': 1,
-        'margin_call': 80,
-        'margin_stop': 40,
-        'pair_decimals': 1,
-        'quote': 'ZUSD',
-        'wsname': 'XBT/USD'},
     'limits': {'amount': {'max': 100000000.0, 'min': 0.002},
                'cost': {'max': None, 'min': 0},
                'price': {'max': None, 'min': 0.1}},
@@ -58,10 +24,6 @@ KRAKEN_BTC_CURRENCY = {
     'code': 'BTC',
     'fee': None,
     'id': 'XXBT',
-    'info': {'aclass': 'currency',
-             'altname': 'XBT',
-             'decimals': 10,
-             'display_decimals': 5},
     'limits': {'amount': {'max': 10000000000.0, 'min': 1e-10},
                'cost': {'max': None, 'min': None},
                'price': {'max': 10000000000.0, 'min': 1e-10},
@@ -103,14 +65,19 @@ class BacktestExchangeBaseIntegrationTest(unittest.TestCase):
         kraken = self.backtest.create_exchange('kraken')
         markets_list = kraken.fetch_markets()
         market = list(filter(lambda x: x['symbol'] == 'BTC/USD', markets_list))
+        del market[0]['info']
         self.assertEqual(market, [KRAKEN_BTC_USD])
 
     def test__fetch_currencies(self):
         kraken = self.backtest.create_exchange('kraken')
-        self.assertEqual(kraken.fetch_currencies()['BTC'], KRAKEN_BTC_CURRENCY)
+        currencies = kraken.fetch_currencies()
+        del currencies['BTC']['info']
+        self.assertEqual(currencies['BTC'], KRAKEN_BTC_CURRENCY)
 
     def test__load_markets(self):
         kraken = self.backtest.create_exchange('kraken')
         kraken.load_markets()
+        del kraken.markets['BTC/USD']['info']
+        del kraken.currencies['BTC']['info']
         self.assertEqual(kraken.currencies['BTC'], KRAKEN_BTC_CURRENCY)
         self.assertEqual(kraken.markets['BTC/USD'], KRAKEN_MARKET_BTC_USD)


### PR DESCRIPTION
Make integration tests more robust by removing the ccxt info object before the comparison