### PR TITLE
Add python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     name: Tests
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'Environment :: Console'
     ],


### PR DESCRIPTION
This is blocked by aiohttp not yet ready for python3.12.
It will be added in 3.9: https://github.com/aio-libs/aiohttp/issues/7675